### PR TITLE
eliminate extra map only job by speculatively building extra filters

### DIFF
--- a/src/java/com/liveramp/cascading_ext/bloom/operation/CreateBloomFilterFromIndices.java
+++ b/src/java/com/liveramp/cascading_ext/bloom/operation/CreateBloomFilterFromIndices.java
@@ -11,6 +11,7 @@ import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntry;
 import cascading.tuple.TupleEntryCollector;
 import com.liveramp.cascading_ext.FixedSizeBitSet;
+import com.liveramp.cascading_ext.bloom.BloomConstants;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.JobConf;
 
@@ -18,22 +19,25 @@ import java.io.IOException;
 
 public class CreateBloomFilterFromIndices extends BaseOperation implements Aggregator {
   private long numBits;
-  private final Tap sideBucket;
-  private TupleEntryCollector collector;
+  private final Tap[] sideBuckets;
+  private TupleEntryCollector[] collectors;
 
-  public CreateBloomFilterFromIndices(Tap sideBucket) {
+  public CreateBloomFilterFromIndices(Tap[] sideBuckets) {
     super(Fields.NONE);
-    this.sideBucket = sideBucket;
+    this.sideBuckets = sideBuckets;
   }
 
   public static class Context {
-    FixedSizeBitSet bitSet;
+    FixedSizeBitSet[] bitSet;
   }
 
   @Override
   public void prepare(FlowProcess flowProcess, OperationCall operationCall){
     try {
-      collector = sideBucket.openForWrite(flowProcess);
+      collectors = new TupleEntryCollector[sideBuckets.length];
+      for(int i = 0; i< sideBuckets.length; i++){
+        collectors[i] = sideBuckets[i].openForWrite(flowProcess);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -41,20 +45,30 @@ public class CreateBloomFilterFromIndices extends BaseOperation implements Aggre
 
   @Override
   public void aggregate(FlowProcess flow, AggregatorCall call) {
+
     Context c = (Context) call.getContext();
-    c.bitSet.set(call.getArguments().getLong(0));
+    long bit = (Long) call.getArguments().getObject(0);
+    int hashNum = (Integer) call.getArguments().getObject(1);
+
+    for(int i = c.bitSet.length-1; i > hashNum-1; i--){
+      c.bitSet[i].set(bit);
+    }
   }
 
   @Override
   public void complete(FlowProcess flow, AggregatorCall call) {
     Context c = (Context) call.getContext();
     TupleEntry group = call.getGroup();
-    collector.add(new Tuple(group.getObject("split"), new BytesWritable(c.bitSet.getRaw())));
+    for(int i = 0; i < collectors.length; i++){
+      collectors[i].add(new Tuple(group.getObject("split"), new BytesWritable(c.bitSet[i].getRaw())));
+    }
   }
 
   @Override
   public void cleanup(FlowProcess flowProcess, OperationCall operationCall){
-    collector.close();
+    for (TupleEntryCollector collector : collectors) {
+      collector.close();
+    }
   }
 
   @Override
@@ -63,7 +77,10 @@ public class CreateBloomFilterFromIndices extends BaseOperation implements Aggre
     numBits = Long.parseLong(conf.get("split.size"));
 
     Context c = new Context();
-    c.bitSet = new FixedSizeBitSet(numBits, new byte[FixedSizeBitSet.getNumBytesToStore(numBits)]);
+    c.bitSet = new FixedSizeBitSet[sideBuckets.length];
+    for(int i = 0; i < c.bitSet.length; i++){
+      c.bitSet[i] = new FixedSizeBitSet(numBits, new byte[FixedSizeBitSet.getNumBytesToStore(numBits)]);
+    }
     call.setContext(c);
   }
 }

--- a/src/java/com/liveramp/cascading_ext/bloom/operation/GetIndices.java
+++ b/src/java/com/liveramp/cascading_ext/bloom/operation/GetIndices.java
@@ -8,6 +8,7 @@ import cascading.operation.OperationCall;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import com.liveramp.cascading_ext.Bytes;
+import com.liveramp.cascading_ext.bloom.BloomConstants;
 import com.liveramp.cascading_ext.bloom.Key;
 import com.liveramp.cascading_ext.hash.Hash64;
 import com.liveramp.cascading_ext.hash.Hash64Function;
@@ -26,14 +27,14 @@ public class GetIndices extends BaseOperation implements Function {
   }
 
   public GetIndices(int hashType) {
-    super(1, new Fields("split", "index"));
+    super(1, new Fields("split", "index", "hash_num"));
     this.hashType = hashType;
   }
 
   public void prepare(FlowProcess flowProcess, OperationCall operationCall){
     JobConf conf = (JobConf) flowProcess.getConfigCopy();
     numBits = Long.parseLong(conf.get("num.bloom.bits"));
-    numHashes = Integer.parseInt(conf.get("num.bloom.hashes"));
+    numHashes = Integer.parseInt(conf.get("max.bloom.hashes"));
     splitSize = Long.parseLong(conf.get("split.size"));
   }
 
@@ -46,7 +47,7 @@ public class GetIndices extends BaseOperation implements Function {
     hash.clear();
     long[] h = hash.hash(new Key(bytes));
     for (int i = 0; i < h.length; i++ ) {
-      Tuple tuple = new Tuple(h[i] / splitSize, h[i] % splitSize);
+      Tuple tuple = new Tuple(h[i] / splitSize, h[i] % splitSize, i);
       call.getOutputCollector().add(tuple);
     }
   }


### PR DESCRIPTION
Skip the extra map-only job over the keyset by building a filter for each of the 1-4 hashes we might use, and choosing which one to use in the flow step strategy.
