### PR TITLE
Reset conf after adding tokens later

### DIFF
--- a/src/main/java/com/liveramp/cascading_ext/CascadingUtil.java
+++ b/src/main/java/com/liveramp/cascading_ext/CascadingUtil.java
@@ -121,6 +121,7 @@ public class CascadingUtil {
     }
 
     serializationTokens.put(token, klass);
+    conf = null;
   }
 
   private Map<String, String> getSerializationsProperty() {


### PR DESCRIPTION
@pwestling 

matches now what is done after addSerialization; otherwise after you add a addSerializationToken directly, if we've gotten a jobconf before, it ignores this prop. 

which does not directly break getFlowConnector... but it does break getFlowProcess, which fetches the jobconf directly, and doesn't add the serialization tokens back.

this whole class is a crime against humanity