### PR TITLE
Added intersection version of absorb

### DIFF
--- a/src/main/java/com/liveramp/cascading_ext/bloom/BloomFilter.java
+++ b/src/main/java/com/liveramp/cascading_ext/bloom/BloomFilter.java
@@ -124,9 +124,25 @@ public class BloomFilter implements Writable {
    * Absorb elements from <i>other</i> into <i>this</i>. Membership test returns true
    * if key belongs to either filter.
    *
-   * @param other The filter to absorb into <i>this</i>.
+   * @param other The filter to union-absorb into <i>this</i>.
    */
-  public void absorb(BloomFilter other) {
+  public void absorbUnion(BloomFilter other) {
+    absorbCheck(other);
+    bits.or(other.bits);
+  }
+
+  /**
+   * Absorb elements only in both <i>other</i> and <i>this</i>. Membership test returns true
+   * if key belongs to both filter.
+   *
+   * @param other The filter to intersection-absorb into <i>this</i>.
+   */
+  public void absorbIntersection(BloomFilter other) {
+    absorbCheck(other);
+    bits.and(other.bits);
+  }
+
+  private void absorbCheck(final BloomFilter other) {
     if (!hashFunction.getHashID().equals(other.hashFunction.getHashID())) {
       throw new IllegalArgumentException("Incompatible hash functions " + hashFunction.getHashID() + " and " + other.hashFunction.getHashID());
     }
@@ -136,7 +152,6 @@ public class BloomFilter implements Writable {
     if (vectorSize != other.vectorSize) {
       throw new IllegalArgumentException("Incompatible vector size " + vectorSize + " and " + other.vectorSize);
     }
-    bits.or(other.bits);
   }
 
   public static BloomFilter read(FileSystem fs, Path path) throws IOException {


### PR DESCRIPTION
@bpodgursky, what do you think of this: a version that and-wises bits to represent elements in both filters? I may have a use case that requires this type of logic.

Was 90% sure this was correct, but found it was actually mentioned in the [wikipedia article](https://en.wikipedia.org/wiki/Bloom_filter#Interesting_properties): 

> Union and intersection of Bloom filters with the same size and set of hash functions can be implemented with bitwise OR and AND operations, respectively.
...
>The intersect operation satisfies a weaker property: the false positive probability in the resulting Bloom filter is at most the false-positive probability in one of the constituent Bloom filters, but may be larger than the false positive probability in the Bloom filter created from scratch using the intersection of the two sets.