### PR TITLE
bump stream-lib version to 2.6.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
-      <version>2.5.0</version>
+      <version>2.6.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
**tl;dr.** v2.5.0 contains a bugged implementation of serialization, where `compressionFactor` is written as a `double` but read as a `long`.

the [commit that fixes this](https://github.com/addthis/stream-lib/commit/a0dd1adc133208b2c1a35d8aded2af176c712dc8) was patched into our internal fork, but only appears in v2.6.0 in the open-source version.