### PR TITLE
Return merged HLL instead of original

### DIFF
--- a/src/main/java/com/liveramp/cascading_ext/combiner/lib/HyperLogLogExactAggregator.java
+++ b/src/main/java/com/liveramp/cascading_ext/combiner/lib/HyperLogLogExactAggregator.java
@@ -77,8 +77,7 @@ public class HyperLogLogExactAggregator implements ExactAggregator<ICardinality>
   public ICardinality finalAggregate(ICardinality aggregate, TupleEntry partialAggregate) {
     try {
       ICardinality hll = HyperLogLogPlus.Builder.build(Bytes.getBytes((BytesWritable) partialAggregate.getObject(0)));
-      aggregate.merge(hll);
-      return aggregate;
+      return aggregate.merge(hll);
     } catch (CardinalityMergeException cme) {
       throw new RuntimeException(cme);
     } catch (IOException e) {


### PR DESCRIPTION
From the javadoc of `merge`. The behavior must've changed between 2.4 and 2.6
```
     * Merges estimators to produce a new estimator for the combined streams
     * of this estimator and those passed as arguments.
     * 
     * Nor this estimator nor the one passed as parameters are modified.
```