### PR TITLE
Retry when getting FileSystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
       <version>1.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.arjie.groundhog</groupId>
+      <artifactId>groundhog</artifactId>
+      <version>0.7.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/liveramp/cascading_ext/FileSystemHelper.java
+++ b/src/main/java/com/liveramp/cascading_ext/FileSystemHelper.java
@@ -76,11 +76,15 @@ public class FileSystemHelper {
     return getFileSystemForPath(new Path(path), config);
   }
 
+  /**
+   * Note, this **does** retry to avoid issues if the XML config files are swapped out while
+   * loading.
+   */
   public static FileSystem getFileSystemForPath(Path path, Configuration config) {
     try {
 
       Callable<RetryResult<FileSystem, NumTries>> callable = RetryBuilders
-          .fixedTriesFixedDelay(3, 5000)
+          .fixedTriesFixedDelay(10, 1000)
           .annotate(() -> path.getFileSystem(config));
 
       return callable.call().getReturnValue();


### PR DESCRIPTION
@pwestling is it reasonable to just do this globally by default?  Alternately we could make it a property and retry selectively, but we'd have to go through and clean all references to getFileSystemForPath(path) and replace them with ones that take a Configuration.