### PR TITLE
consider HA RM: there might be multiple RMs

### DIFF
--- a/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
+++ b/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
@@ -3,13 +3,16 @@ package com.liveramp.cascading_ext.yarn;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.Sets;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapred.JobConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +49,7 @@ public class YarnApiHelper {
       return trackingUrl;
     }
 
-    public TwoNestedMap<String, String, Long> asCounterMap(){
+    public TwoNestedMap<String, String, Long> asCounterMap() {
       TwoNestedMap<String, String, Long> counters = new TwoNestedMap<>();
       counters.put(YarnApiHelper.YARN_STATS_GROUP,
           YarnApiHelper.YARN_MEM_SECONDS_COUNTER, getMbSeconds());
@@ -76,12 +79,60 @@ public class YarnApiHelper {
   }
 
   public static Optional<ApplicationInfo> getYarnAppInfo(Configuration conf, String appId) {
-    String yarnApiAddress = conf.get("yarn.resourcemanager.webapp.address", "");
-    if ( !yarnApiAddress.isEmpty()) {
+    String yarnApiAddress = getYarnApiAddress(conf);
+    if (!yarnApiAddress.isEmpty()) {
       return getYarnAppInfo(yarnApiAddress, appId);
     } else {
       return Optional.empty();
     }
+  }
+
+  /***
+   * Gets a yarn api address. This also works if you are using more than one resource manager.
+   * If there's more than one resource manager this method will return the address of the first
+   * resource manager with which it was able to successfully connect to. It will return an empty
+   * string if there were no resource manager it could successfully connect to.
+   */
+  private static String getYarnApiAddress(Configuration conf) {
+    Set<String> yarnApiAddresses = getYarnApiAddresses(conf);
+
+    try {
+      for (String yarnApiAddress : yarnApiAddresses) {
+        if (successfulConnection(yarnApiAddress)) {
+          return yarnApiAddress;
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Error getting yarn api address:", e);
+    }
+
+    return "";
+  }
+
+  static Set<String> getYarnApiAddresses(Configuration conf) {
+    String emptyString = "";
+    String rmIdsConf = conf.get("yarn.resourcemanager.ha.rm-ids", emptyString);
+
+    if (rmIdsConf.isEmpty()) {
+      String yarnApiAddress = conf.get("yarn.resourcemanager.webapp.address", emptyString);
+      return yarnApiAddress.isEmpty() ? Sets.newHashSet() : Sets.newHashSet(yarnApiAddress);
+    }
+
+    String[] allRmIds = rmIdsConf.split(",");
+    return Arrays.stream(allRmIds)
+        .map(rmId -> conf.get("yarn.resourcemanager.webapp.address." + rmId, emptyString))
+        .filter(address -> !address.isEmpty())
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean successfulConnection(String urlString) throws IOException {
+    URL url = new URL(urlString);
+    HttpURLConnection urlConnection = (HttpURLConnection)url.openConnection();
+    urlConnection.setConnectTimeout(10000);
+    urlConnection.setReadTimeout(10000);
+    int responseCode = urlConnection.getResponseCode();
+
+    return responseCode == 200;
   }
 
   public static Optional<ApplicationInfo> getYarnAppInfo(String yarnApiAddress, String appId) {

--- a/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
+++ b/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
@@ -44,11 +44,6 @@ public class TestYarnApiHelper {
 
   @Test
   public void testGetYarnApiAddressNoRMs() {
-    conf.set("yarn.resourcemanager.ha.rm-ids", "");
-    conf.set("yarn.resourcemanager.webapp.address." + RM1, "");
-    conf.set("yarn.resourcemanager.webapp.address." + RM2, "");
-    conf.set("yarn.resourcemanager.webapp.address", "");
-
     Set<String> yarnApiAddresses = YarnApiHelper.getYarnApiAddresses(conf);
     assertEquals(Sets.newHashSet(), yarnApiAddresses);
   }

--- a/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
+++ b/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
@@ -44,6 +44,11 @@ public class TestYarnApiHelper {
 
   @Test
   public void testGetYarnApiAddressNoRMs() {
+    conf.unset("yarn.resourcemanager.ha.rm-ids");
+    conf.unset("yarn.resourcemanager.webapp.address." + RM1);
+    conf.unset("yarn.resourcemanager.webapp.address." + RM2);
+    conf.unset("yarn.resourcemanager.webapp.address");
+
     Set<String> yarnApiAddresses = YarnApiHelper.getYarnApiAddresses(conf);
     assertEquals(Sets.newHashSet(), yarnApiAddresses);
   }

--- a/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
+++ b/src/test/java/com/liveramp/cascading_ext/yarn/TestYarnApiHelper.java
@@ -1,0 +1,55 @@
+package com.liveramp.cascading_ext.yarn;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestYarnApiHelper {
+  private static final String RM1 = "rm149696";
+  private static final String RM2 = "rm149698";
+
+  private static final String ADDRESS1 = "address1";
+  private static final String ADDRESS2 = "address2";
+
+  private Configuration conf;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = new Configuration();
+  }
+
+  @Test
+  public void testGetYarnApiAddressMultipleRMs() {
+    conf.set("yarn.resourcemanager.ha.rm-ids", RM1 + "," + RM2);
+    conf.set("yarn.resourcemanager.webapp.address." + RM1, ADDRESS1);
+    conf.set("yarn.resourcemanager.webapp.address." + RM2, ADDRESS2);
+
+    Set<String> yarnApiAddresses = YarnApiHelper.getYarnApiAddresses(conf);
+
+    assertEquals(Sets.newHashSet(ADDRESS1, ADDRESS2), yarnApiAddresses);
+  }
+
+  @Test
+  public void testGetYarnApiAddressOneRM() {
+    conf.set("yarn.resourcemanager.webapp.address", ADDRESS1);
+
+    Set<String> yarnApiAddresses = YarnApiHelper.getYarnApiAddresses(conf);
+    assertEquals(Sets.newHashSet(ADDRESS1), yarnApiAddresses);
+  }
+
+  @Test
+  public void testGetYarnApiAddressNoRMs() {
+    conf.set("yarn.resourcemanager.ha.rm-ids", "");
+    conf.set("yarn.resourcemanager.webapp.address." + RM1, "");
+    conf.set("yarn.resourcemanager.webapp.address." + RM2, "");
+    conf.set("yarn.resourcemanager.webapp.address", "");
+
+    Set<String> yarnApiAddresses = YarnApiHelper.getYarnApiAddresses(conf);
+    assertEquals(Sets.newHashSet(), yarnApiAddresses);
+  }
+}


### PR DESCRIPTION
Currently, we are assuming that there's just one resource manager. When having multiple resource managers (HA) the key that we need to use to get the address from the conf is different.

With the changes in this PR we are covering both cases: one and multiple RMs