### PR TITLE
Yarn connection catch exception

### DIFF
--- a/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
+++ b/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
@@ -97,16 +97,12 @@ public class YarnApiHelper {
    */
   private static Optional<String> getYarnApiAddress(Configuration conf) {
     Set<String> yarnApiAddresses = getYarnApiAddresses(conf);
-    try {
-      for (String yarnApiAddress : yarnApiAddresses) {
-        if (successfulConnection(yarnApiAddress)) {
-          return Optional.of(yarnApiAddress);
-        }
+    for (String yarnApiAddress : yarnApiAddresses) {
+      if (successfulConnection(yarnApiAddress)) {
+        return Optional.of(yarnApiAddress);
       }
-    } catch (IOException e) {
-      LOG.error("Error getting yarn api address:", e);
     }
-
+    LOG.error("Failed to connect to a all yarn api addresses: " + yarnApiAddresses);
     return Optional.empty();
   }
 

--- a/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
+++ b/src/main/java/com/liveramp/cascading_ext/yarn/YarnApiHelper.java
@@ -120,17 +120,20 @@ public class YarnApiHelper {
         .collect(Collectors.toSet());
   }
 
-  private static boolean successfulConnection(String yarnApiAddress) throws IOException {
-    String urlString = "http://" + yarnApiAddress + "/ws/v1/cluster";
-    URL url = new URL(urlString);
-    HttpURLConnection urlConnection = (HttpURLConnection)url.openConnection();
-    urlConnection.setConnectTimeout((int)Duration.ofSeconds(10).toMillis());
-    urlConnection.setReadTimeout((int)Duration.ofSeconds(10).toMillis());
-    urlConnection.setRequestMethod("GET");
-
-    int responseCode = urlConnection.getResponseCode();
-
-    return responseCode == 200;
+  private static boolean successfulConnection(String yarnApiAddress) {
+    try {
+      String urlString = "http://" + yarnApiAddress + "/ws/v1/cluster";
+      URL url = new URL(urlString);
+      HttpURLConnection urlConnection = (HttpURLConnection)url.openConnection();
+      urlConnection.setConnectTimeout((int)Duration.ofSeconds(10).toMillis());
+      urlConnection.setReadTimeout((int)Duration.ofSeconds(10).toMillis());
+      urlConnection.setRequestMethod("GET");
+      int responseCode = urlConnection.getResponseCode();
+      return responseCode == 200;
+    } catch (IOException e) {
+      LOG.warn("Error while conntecting to " + yarnApiAddress, e);
+      return false;
+    }
   }
 
   public static Optional<ApplicationInfo> getYarnAppInfo(String yarnApiAddress, String appId) {


### PR DESCRIPTION
https://github.com/LiveRamp/cascading_ext/pull/90 follow up

The above PR only works when all RMs are up. If we check for a successful connection on a RM that was down then it would throw a `connection refused` exception.

In this PR I'm making two changes:
1. Log an error when we couldn't find a RM we could successfully connect to.
2. If an `IOException` is thrown while checking for a successful connection then we will catch the exception, we will log a warning and the method will return `false` (no successful connection)