### PR TITLE
Updated reference to Cascading to 4.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,19 +76,19 @@
     <dependency>
       <groupId>net.wensel</groupId>
       <artifactId>cascading-core</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
     </dependency>
 
     <dependency>
       <groupId>net.wensel</groupId>
       <artifactId>cascading-hadoop3-common</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
     </dependency>
 
     <dependency>
       <groupId>net.wensel</groupId>
       <artifactId>cascading-hadoop3-mr1</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This solves a memory leak issue on newer versions of Hadoop